### PR TITLE
Fix error on block level invalid syntax

### DIFF
--- a/src/AttributesInlineProcessor.php
+++ b/src/AttributesInlineProcessor.php
@@ -33,7 +33,7 @@ class AttributesInlineProcessor implements InlineProcessorInterface
 
             if ($node->isBlock()) {
                 $target = $node->parent();
-                if (($parent = $target->parent()) instanceof ListItem && $parent->parent() instanceof ListBlock && $parent->parent()->isTight()) {
+                if ($target && ($parent = $target->parent()) instanceof ListItem && $parent->parent() instanceof ListBlock && $parent->parent()->isTight()) {
                     $target = $parent;
                 }
             } else {

--- a/tests/Functional/data/more_attributes.html
+++ b/tests/Functional/data/more_attributes.html
@@ -4,3 +4,4 @@
 <h3>Header no attributes</h3>
 <p class="first second third fourth fifth" id="par1">Paragraph with a.</p>
 <p id="par2">Paragraph with <em class="chello">emphasis</em></p>
+<p id="invalid"><a href="example.com">Invalid</a></p>

--- a/tests/Functional/data/more_attributes.md
+++ b/tests/Functional/data/more_attributes.md
@@ -16,3 +16,5 @@ Header with attributes {#header1}
 
 Paragraph with *emphasis*{.chello}
    {#par2}
+
+{#invalid} [Invalid](example.com)


### PR DESCRIPTION
Fix for issue #9 ; checks that the block element has a parent