### PR TITLE
Use the new "commonmark-extension" package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "webuni/commonmark-attributes-extension",
-    "type": "library",
+    "type": "commonmark-extension",
     "description": "The attributes extension adds a syntax to define attributes on the various HTML elements in CommonMark PHP implementation.",
     "keywords": ["markdown","attributes","commonmark"],
     "homepage": "https://github.com/webuni/commonmark-attributes-extension",


### PR DESCRIPTION
This makes it easier for people to find extensions on Packagist: https://packagist.org/packages/league/commonmark-ext-autolink?type=commonmark-extension